### PR TITLE
Add repository signing key

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -4,6 +4,6 @@ class raid::repo::debian {
     release    => $::lsbdistcodename,
     repos      => 'main',
     key        => '23B3D3B4',
-    key_source => 'http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key',
+    key_server => 'pgp.mit.edu',
   }
 }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,13 +1,9 @@
 class raid::repo::debian {
   apt::source { 'raid':
-    location    => 'http://hwraid.le-vert.net/debian',
-    release     => $::lsbdistcodename,
-    repos       => 'main',
-  }
-
-  #FIXME the repo sucks a bit http://hwraid.le-vert.net/ticket/12
-  apt::conf { 'unauthenticated':
-    priority => '99',
-    content  => 'APT::Get::AllowUnauthenticated yes;'
+    location   => 'http://hwraid.le-vert.net/debian',
+    release    => $::lsbdistcodename,
+    repos      => 'main',
+    key        => '23B3D3B4',
+    key_source => 'http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key',
   }
 }

--- a/spec/classes/raid_spec.rb
+++ b/spec/classes/raid_spec.rb
@@ -29,7 +29,7 @@ describe 'raid' do
     it { should_not contain_class 'raid::service' }
     it { should_not contain_class 'raid::nagios' }
     it { should contain_class 'raid::repo::debian' }
-    it { should contain_apt__source 'raid' }
+    it { should contain_apt__source('raid').with_key('23B3D3B4') }
 
     describe "No RAID Controller" do
         it { should contain_notify 'No RAID Controller found' }


### PR DESCRIPTION
Removed Apt::Get::AllowUnauthenticated setting

`/etc/apt/apt.conf.d/99unauthenticated` should to be removed manually.
