### PR TITLE
use a serverpool instead of single pgp server

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -4,6 +4,6 @@ class raid::repo::debian {
     release    => $::lsbdistcodename,
     repos      => 'main',
     key        => '23B3D3B4',
-    key_server => 'pgp.mit.edu',
+    key_server => 'subkeys.pgp.net',
   }
 }


### PR DESCRIPTION
because pgp.mit.edu hangs from time to time
