### PR TITLE
Add support for MegaRAID SAS 2208 [Thunderbolt]

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,8 @@ class raid::params {
   case $controller_0_vendor {
     /^LSI/: {
       case $controller_0_device {
-        'LSI MegaSAS 9260', 'MegaRAID SAS TB': {
+        'LSI MegaSAS 9260', 'MegaRAID SAS TB',
+        'MegaRAID SAS 2208 [Thunderbolt]': {
           $packages = [ 'megaclisas-status', 'megacli' ]
           $nagioscheck = [ '/usr/sbin/megaclisas-status' ]
           $service = 'megaclisas-statusd'


### PR DESCRIPTION
This is how is recognised the LSI MegaRAID SAS 9271-4i shipped by OVH
for this machine :
http://www.ovh.com/us/dedicated-servers/enterprise/2014-SP-64.xml#custom
